### PR TITLE
Update VideoView.swift

### DIFF
--- a/VideoPlayerSwiftUI/Views/VideoView.swift
+++ b/VideoPlayerSwiftUI/Views/VideoView.swift
@@ -9,20 +9,27 @@ import SwiftUI
 import AVKit
 
 struct VideoView: View {
-    var video : Video
-@State private var player = AVPlayer()
+    var video: Video
+    @State private var player = AVPlayer()
+
     var body: some View {
-    VideoPlayer(player: player)
-            .edgesIgnoringSafeArea(.all)
-            .onAppear {
-                if let link =
-                video.videoFiles.first?.link{
-                    player = AVPlayer(url: URL(string: link)!)
-                    player.play()
+        GeometryReader { geometry in
+            VideoPlayer(player: player)
+                .onAppear {
+                    if let link = video.videoFiles.first?.link {
+                        player = AVPlayer(url: URL(string: link)!)
+                        player.play()
+                    }
                 }
-            }
+                .aspectRatio(contentMode: .fill)
+                .frame(width: geometry.size.width, height: geometry.size.height)
+                
+        }
+        .edgesIgnoringSafeArea(.all)
     }
 }
+
+
 
 struct VideoView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
I set the frame of the VideoPlayer to match the width and height of the available space obtained from the GeometryReader using geometry.size.width and geometry.size.height. The edgesIgnoringSafeArea(.all) modifier is also used to ensure the video player fills the entire screen, including the safe areas.